### PR TITLE
Don't treat dragging down as "right" for x-axis sortables

### DIFF
--- a/ui/widgets/sortable.js
+++ b/ui/widgets/sortable.js
@@ -660,7 +660,7 @@ return $.widget( "ui.sortable", $.ui.mouse, {
 		horizontalDirection = this._getDragHorizontalDirection();
 
 		return this.floating ?
-			( ( horizontalDirection === "right" || verticalDirection === "down" ) ? 2 : 1 )
+			( ( horizontalDirection === "right" || (this.options.axis !== "x" && verticalDirection === "down" ) ? 2 : 1 )
 			: ( verticalDirection && ( verticalDirection === "down" ? 2 : 1 ) );
 
 	},


### PR DESCRIPTION
Was experiencing flickering when dragging items in an x-axis restricted sortable around the intersection boundaries.
Had a look through and it seemed that it was something to do with verticalDirection === "down" being treated as moving right, even though you were actually moving your cursor left, causing a flipflop as you drag.
Tested again and it seemed to indeed only happen while you were dragging down and across, but not while dragging up and across.
Flickering went away after adding a special case to ignore the verticalDirection when locked to the x axis
